### PR TITLE
Allow activity context to be inherited

### DIFF
--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/CurrentActivityExecutionContext.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/CurrentActivityExecutionContext.java
@@ -26,7 +26,7 @@ import com.amazonaws.services.simpleworkflow.flow.ActivityExecutionContextProvid
  */
 public class CurrentActivityExecutionContext {
 
-    private final static ThreadLocal<ActivityExecutionContext> CURRENT = new ThreadLocal<ActivityExecutionContext>();
+    private final static InheritableThreadLocal<ActivityExecutionContext> CURRENT = new InheritableThreadLocal<ActivityExecutionContext>();
 
     /**
      * This is used by activity implementation to get access to the current


### PR DESCRIPTION
When a long-running activity needs to spawn child threads to do a set of
tasks, those threads lose the ability to send SWF heartbeat messages due
to the `ActivityExecutionContext` not being available in their local
thread storage.

By using an `InheritableThreadLocal`, rather than just a `ThreadLocal`,
child threads would have access to this context by default, enabling
them to heartbeat as needed.

Custom code could be added to manually pass this contextual information
to child threads, but this seems to be a more appropriate point of
control.

It could be argued that multiple threads in a single activity like this
should be broken up into individual activities. I agree with this, but
such architectural changes require far more resources.