### PR TITLE
Release the internal Flow-3.8 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-swf-libraries</artifactId>
-  <version>1.11.24-SNAPSHOT</version>
+  <version>1.12.0</version>
   <packaging>jar</packaging>
   <name>Java Libraries for Amazon Simple WorkFlow</name>
   <description>This artifact contains the higher level libraries that can be used in Amazon Simple WorkFlow Service</description>
@@ -31,7 +31,7 @@
     <url>https://github.com/aws/aws-swf-flow-library.git</url>
   </scm>
   <properties>
-    <spring.version>5.2.9.RELEASE</spring.version>
+    <spring.version>5.3.14</spring.version>
     <freemarker.version>2.3.9</freemarker.version>
     <aspectj.version>1.8.2</aspectj.version>
     <jre.version>1.8</jre.version>
@@ -84,7 +84,27 @@
       <version>${aspectj.version}</version>
       <optional>true</optional>
     </dependency>
-    
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.22</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.13.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.13.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.1</version>
+    </dependency>
    <!-- JUnit is needed to compile the support classes for the workflow service -->
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/ActivityWorker.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/ActivityWorker.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
+import com.amazonaws.services.simpleworkflow.flow.config.SimpleWorkflowClientConfig;
 import com.amazonaws.services.simpleworkflow.flow.generic.ActivityImplementation;
 import com.amazonaws.services.simpleworkflow.flow.pojo.POJOActivityImplementationFactory;
 import com.amazonaws.services.simpleworkflow.flow.worker.GenericActivityWorker;
@@ -32,7 +33,11 @@ public class ActivityWorker implements WorkerBase {
     private final POJOActivityImplementationFactory factory;
 
     public ActivityWorker(AmazonSimpleWorkflow service, String domain, String taskListToPoll) {
-        this(new GenericActivityWorker(service, domain, taskListToPoll));
+        this(service, domain, taskListToPoll, null);
+    }
+
+    public ActivityWorker(AmazonSimpleWorkflow service, String domain, String taskListToPoll, SimpleWorkflowClientConfig config) {
+        this(new GenericActivityWorker(service, domain, taskListToPoll, config));
     }
 
     public ActivityWorker(GenericActivityWorker genericWorker) {
@@ -87,22 +92,6 @@ public class ActivityWorker implements WorkerBase {
         factory.setDataConverter(dataConverter);
     }
 
-    /**
-     * @deprecated This method has been deprecated since flow-3.7. Try using {@link #getExecuteThreadCount()} instead.
-     */
-    @Deprecated
-    public int getTaskExecutorThreadPoolSize() {
-        return genericWorker.getTaskExecutorThreadPoolSize();
-    }
-
-    /**
-     * @deprecated This method has been deprecated since flow-3.7. Try using {@link #setExecuteThreadCount(int)} instead.
-     */
-    @Deprecated
-    public void setTaskExecutorThreadPoolSize(int taskExecutorThreadPoolSize) {
-        genericWorker.setTaskExecutorThreadPoolSize(taskExecutorThreadPoolSize);
-    }
-
     @Override
     public boolean shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         return genericWorker.shutdownAndAwaitTermination(timeout, unit);
@@ -111,6 +100,11 @@ public class ActivityWorker implements WorkerBase {
     @Override
     public void shutdownNow() {
         genericWorker.shutdownNow();
+    }
+
+    @Override
+    public SimpleWorkflowClientConfig getClientConfig() {
+        return genericWorker.getClientConfig();
     }
 
     @Override
@@ -226,6 +220,16 @@ public class ActivityWorker implements WorkerBase {
     @Override
     public void setDisableServiceShutdownOnStop(boolean disableServiceShutdownOnStop) {
         genericWorker.setDisableServiceShutdownOnStop(disableServiceShutdownOnStop);
+    }
+
+    @Override
+    public boolean isAllowCoreThreadTimeOut() {
+        return genericWorker.isAllowCoreThreadTimeOut();
+    }
+
+    @Override
+    public void setAllowCoreThreadTimeOut(boolean allowCoreThreadTimeOut) {
+        genericWorker.setAllowCoreThreadTimeOut(allowCoreThreadTimeOut);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/ChildWorkflowIdHandler.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/ChildWorkflowIdHandler.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.simpleworkflow.flow;
+
+import com.amazonaws.services.simpleworkflow.model.WorkflowExecution;
+import java.util.function.Supplier;
+
+public interface ChildWorkflowIdHandler {
+
+    /**
+     * Generate a workflow id for a new child workflow.
+     *
+     * @param currentWorkflow The current (i.e. parent) workflow execution
+     * @param nextId Can be called to get a replay-safe id that is unique in the
+     *               context of the current workflow.
+     *
+     * @return A new child workflow id
+     */
+    String generateWorkflowId(WorkflowExecution currentWorkflow, Supplier<String> nextId);
+
+    /**
+     * Extract the child workflow id that was provided when
+     * making a decision to start a child workflow.
+     *
+     * @param childWorkflowId The actual child workflow id
+     * @return The original requested child workflow id (may be the same as the actual child workflow id)
+     */
+    String extractRequestedWorkflowId(String childWorkflowId);
+}

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/DefaultChildWorkflowIdHandler.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/DefaultChildWorkflowIdHandler.java
@@ -12,16 +12,20 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.amazonaws.services.simpleworkflow.flow.generic;
+package com.amazonaws.services.simpleworkflow.flow;
 
-import com.amazonaws.services.simpleworkflow.flow.core.Promise;
+import com.amazonaws.services.simpleworkflow.model.WorkflowExecution;
+import java.util.function.Supplier;
 
+public class DefaultChildWorkflowIdHandler implements ChildWorkflowIdHandler {
 
-public interface StartChildWorkflowReply {
+    @Override
+    public String generateWorkflowId(WorkflowExecution currentWorkflow, Supplier<String> nextId) {
+        return String.format("%s:%s", currentWorkflow.getRunId(), nextId.get());
+    }
 
-    public String getWorkflowId();
-
-    public String getRunId();
-    
-    public Promise<String> getResult();
+    @Override
+    public String extractRequestedWorkflowId(String childWorkflowId) {
+        return childWorkflowId;
+    }
 }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/DynamicActivitiesClientImpl.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/DynamicActivitiesClientImpl.java
@@ -45,7 +45,7 @@ public class DynamicActivitiesClientImpl implements DynamicActivitiesClient {
     }
 
     public DynamicActivitiesClientImpl(ActivitySchedulingOptions schedulingOptions, DataConverter dataConverter,
-            GenericActivityClient genericClient) {
+                                       GenericActivityClient genericClient) {
         this.genericClient = genericClient;
 
         if (schedulingOptions == null) {
@@ -92,7 +92,7 @@ public class DynamicActivitiesClientImpl implements DynamicActivitiesClient {
     }
 
     public <T> Promise<T> scheduleActivity(final ActivityType activityType, final Promise<?>[] arguments,
-            final ActivitySchedulingOptions optionsOverride, final Class<T> returnType, final Promise<?>... waitFor) {
+                                           final ActivitySchedulingOptions optionsOverride, final Class<T> returnType, final Promise<?>... waitFor) {
         return new Functor<T>(arguments) {
 
             @Override
@@ -110,7 +110,7 @@ public class DynamicActivitiesClientImpl implements DynamicActivitiesClient {
     }
 
     public <T> Promise<T> scheduleActivity(final ActivityType activityType, final Object[] arguments,
-            final ActivitySchedulingOptions optionsOverride, final Class<T> returnType, Promise<?>... waitFor) {
+                                           final ActivitySchedulingOptions optionsOverride, final Class<T> returnType, Promise<?>... waitFor) {
         final Settable<T> result = new Settable<T>();
         new TryCatchFinally(waitFor) {
 
@@ -120,7 +120,7 @@ public class DynamicActivitiesClientImpl implements DynamicActivitiesClient {
             protected void doTry() throws Throwable {
                 ExecuteActivityParameters parameters = new ExecuteActivityParameters();
                 parameters.setActivityType(activityType);
-                String stringInput = dataConverter.toData(arguments);
+                final String stringInput = dataConverter.toData(arguments);
                 parameters.setInput(stringInput);
                 final ExecuteActivityParameters _scheduleParameters_ = parameters.createExecuteActivityParametersFromOptions(
                         schedulingOptions, optionsOverride);

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/JsonDataConverter.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/JsonDataConverter.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -56,7 +57,11 @@ public class JsonDataConverter extends DataConverter {
 
         // This will allow including type information all non-final types.  This allows correct
         // serialization/deserialization of generic collections, for example List<MyType>.
-        mapper.enableDefaultTyping(DefaultTyping.NON_FINAL);
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(Object.class)
+                        .build(),
+                DefaultTyping.NON_FINAL);
     }
 
     /**

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/ManualActivityCompletionClientFactoryImpl.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/ManualActivityCompletionClientFactoryImpl.java
@@ -15,6 +15,7 @@
 package com.amazonaws.services.simpleworkflow.flow;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
+import com.amazonaws.services.simpleworkflow.flow.config.SimpleWorkflowClientConfig;
 
 
 public class ManualActivityCompletionClientFactoryImpl extends ManualActivityCompletionClientFactory {
@@ -22,25 +23,40 @@ public class ManualActivityCompletionClientFactoryImpl extends ManualActivityCom
     private AmazonSimpleWorkflow service;
 
     private DataConverter dataConverter = new JsonDataConverter();
-    
+
+    private SimpleWorkflowClientConfig config;
+
     public ManualActivityCompletionClientFactoryImpl(AmazonSimpleWorkflow service) {
-        this.service = service;
+        this(service, null);
     }
-    
+
+    public ManualActivityCompletionClientFactoryImpl(AmazonSimpleWorkflow service, SimpleWorkflowClientConfig config) {
+        this.service = service;
+        this.config = config;
+    }
+
     public AmazonSimpleWorkflow getService() {
         return service;
     }
-    
+
     public void setService(AmazonSimpleWorkflow service) {
         this.service = service;
     }
-    
+
     public DataConverter getDataConverter() {
         return dataConverter;
     }
-    
+
     public void setDataConverter(DataConverter dataConverter) {
         this.dataConverter = dataConverter;
+    }
+
+    public SimpleWorkflowClientConfig getClientConfig() {
+        return config;
+    }
+
+    public void setClientConfig(SimpleWorkflowClientConfig config) {
+        this.config = config;
     }
 
     @Override
@@ -51,7 +67,7 @@ public class ManualActivityCompletionClientFactoryImpl extends ManualActivityCom
         if (dataConverter == null) {
             throw new IllegalStateException("required property dataConverter is null");
         }
-        return new ManualActivityCompletionClientImpl(service, taskToken, dataConverter);
+        return new ManualActivityCompletionClientImpl(service, taskToken, dataConverter, config);
     }
 
 }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/WorkerBase.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/WorkerBase.java
@@ -18,10 +18,13 @@ import java.lang.Thread.UncaughtExceptionHandler;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
 import com.amazonaws.services.simpleworkflow.flow.annotations.SkipTypeRegistration;
+import com.amazonaws.services.simpleworkflow.flow.config.SimpleWorkflowClientConfig;
 
 public interface WorkerBase extends SuspendableWorker {
 
     AmazonSimpleWorkflow getService();
+
+    SimpleWorkflowClientConfig getClientConfig();
 
     String getDomain();
 
@@ -140,11 +143,8 @@ public interface WorkerBase extends SuspendableWorker {
 
     /**
      * Defines how many concurrent threads are used by the given worker to poll
-     * the specified task list. Default is 1. Note that in case of
-     * {@link ActivityWorker} two separate threads pools are used. One for
-     * polling and another one for executing activities. The size of the
-     * activity execution thread pool is defined through
-     * {@link ActivityWorker#setTaskExecutorThreadPoolSize(int)}.
+     * the specified task list. Default is 1. The size of the task execution
+     * thread pool is defined through {@link #setExecuteThreadCount(int)}.
      */
     void setPollThreadCount(int threadCount);
 
@@ -176,5 +176,13 @@ public interface WorkerBase extends SuspendableWorker {
     void setDisableTypeRegistrationOnStart(boolean disableTypeRegistrationOnStart);
 
     boolean isDisableTypeRegistrationOnStart();
+
+    /**
+     * When set to true allows the task execution threads to terminate
+     * if they have been idle for 1 minute.
+     */
+    void setAllowCoreThreadTimeOut(boolean allowCoreThreadTimeOut);
+
+    boolean isAllowCoreThreadTimeOut();
 
 }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/WorkflowClientFactoryExternalBase.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/WorkflowClientFactoryExternalBase.java
@@ -15,6 +15,7 @@
 package com.amazonaws.services.simpleworkflow.flow;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
+import com.amazonaws.services.simpleworkflow.flow.config.SimpleWorkflowClientConfig;
 import com.amazonaws.services.simpleworkflow.flow.generic.GenericWorkflowClientExternal;
 import com.amazonaws.services.simpleworkflow.flow.worker.GenericWorkflowClientExternalImpl;
 import com.amazonaws.services.simpleworkflow.model.WorkflowExecution;
@@ -29,6 +30,10 @@ public abstract class WorkflowClientFactoryExternalBase<T> implements WorkflowCl
 
     public WorkflowClientFactoryExternalBase(AmazonSimpleWorkflow service, String domain) {
         this(new GenericWorkflowClientExternalImpl(service, domain));
+    }
+
+    public WorkflowClientFactoryExternalBase(AmazonSimpleWorkflow service, String domain, SimpleWorkflowClientConfig config) {
+        this(new GenericWorkflowClientExternalImpl(service, domain, config));
     }
 
     public WorkflowClientFactoryExternalBase() {
@@ -100,7 +105,7 @@ public abstract class WorkflowClientFactoryExternalBase<T> implements WorkflowCl
 
     @Override
     public T getClient(WorkflowExecution workflowExecution, StartWorkflowOptions options, DataConverter dataConverter,
-            GenericWorkflowClientExternal genericClient) {
+                       GenericWorkflowClientExternal genericClient) {
         checkGenericClient();
         return createClientInstance(workflowExecution, options, dataConverter, genericClient);
     }
@@ -114,6 +119,6 @@ public abstract class WorkflowClientFactoryExternalBase<T> implements WorkflowCl
     }
 
     protected abstract T createClientInstance(WorkflowExecution workflowExecution, StartWorkflowOptions options,
-            DataConverter dataConverter, GenericWorkflowClientExternal genericClient);
+                                              DataConverter dataConverter, GenericWorkflowClientExternal genericClient);
 
 }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/WorkflowWorker.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/WorkflowWorker.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
+import com.amazonaws.services.simpleworkflow.flow.config.SimpleWorkflowClientConfig;
 import com.amazonaws.services.simpleworkflow.flow.pojo.POJOWorkflowDefinitionFactoryFactory;
 import com.amazonaws.services.simpleworkflow.flow.worker.GenericWorkflowWorker;
 import com.amazonaws.services.simpleworkflow.model.WorkflowType;
@@ -38,11 +39,20 @@ public class WorkflowWorker implements WorkerBase {
         this(new GenericWorkflowWorker(service, domain, taskListToPoll));
     }
 
+    public WorkflowWorker(AmazonSimpleWorkflow service, String domain, String taskListToPoll, SimpleWorkflowClientConfig config) {
+        this(new GenericWorkflowWorker(service, domain, taskListToPoll, config));
+    }
+
     public WorkflowWorker(GenericWorkflowWorker genericWorker) {
         Objects.requireNonNull(genericWorker,"the workflow worker is required");
         this.genericWorker = genericWorker;
         this.factoryFactory =  new POJOWorkflowDefinitionFactoryFactory();
         this.genericWorker.setWorkflowDefinitionFactoryFactory(factoryFactory);
+    }
+
+    @Override
+    public SimpleWorkflowClientConfig getClientConfig() {
+        return genericWorker.getClientConfig();
     }
 
     @Override
@@ -162,6 +172,16 @@ public class WorkflowWorker implements WorkerBase {
     }
 
     @Override
+    public boolean isAllowCoreThreadTimeOut() {
+        return genericWorker.isAllowCoreThreadTimeOut();
+    }
+
+    @Override
+    public void setAllowCoreThreadTimeOut(boolean allowCoreThreadTimeOut) {
+        genericWorker.setAllowCoreThreadTimeOut(allowCoreThreadTimeOut);
+    }
+
+    @Override
     public double getPollBackoffCoefficient() {
         return genericWorker.getPollBackoffCoefficient();
     }
@@ -190,6 +210,10 @@ public class WorkflowWorker implements WorkerBase {
     @Override
     public void setExecuteThreadCount(int threadCount) {
         genericWorker.setExecuteThreadCount(threadCount);
+    }
+
+    public void setChildWorkflowIdHandler(ChildWorkflowIdHandler childWorkflowIdHandler) {
+        genericWorker.setChildWorkflowIdHandler(childWorkflowIdHandler);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/common/RequestTimeoutHelper.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/common/RequestTimeoutHelper.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.simpleworkflow.flow.common;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.services.simpleworkflow.flow.config.SimpleWorkflowClientConfig;
+
+public class RequestTimeoutHelper {
+    public static void overrideDataPlaneRequestTimeout(AmazonWebServiceRequest serviceRequest, SimpleWorkflowClientConfig config) {
+        if (serviceRequest != null && config != null) {
+            serviceRequest.setSdkRequestTimeout(config.getDataPlaneRequestTimeoutInMillis());
+        }
+    }
+
+    public static void overrideControlPlaneRequestTimeout(AmazonWebServiceRequest serviceRequest, SimpleWorkflowClientConfig config) {
+        if (serviceRequest != null && config != null) {
+            serviceRequest.setSdkRequestTimeout(config.getControlPlaneRequestTimeoutInMillis());
+        }
+    }
+
+    public static void overridePollRequestTimeout(AmazonWebServiceRequest serviceRequest, SimpleWorkflowClientConfig config) {
+        if (serviceRequest != null && config != null) {
+            serviceRequest.setSdkRequestTimeout(config.getPollingRequestTimeoutInMillis());
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/config/SimpleWorkflowClientConfig.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/config/SimpleWorkflowClientConfig.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.simpleworkflow.flow.config;
+
+import java.time.Duration;
+
+public class SimpleWorkflowClientConfig {
+    private final Duration dataPlaneRequestTimeout;
+    private final Duration pollingRequestTimeout;
+    private final Duration controlPlaneRequestTimeout;
+    private static final int DEFAULT_POLLING_REQUEST_TIMEOUT_IN_SEC = 70;
+    private static final int DEFAULT_DATA_PLANE_REQUEST_TIMEOUT_IN_SEC = 6;
+    private static final int DEFAULT_CONTROL_PLANE_REQUEST_TIMEOUT_IN_SEC = 10;
+
+    /**
+     * Class method to provide SimpleWorkflowClientConfig with default timeouts
+     *
+     * @return SimpleWorkflowClientConfig instance
+     */
+    public static SimpleWorkflowClientConfig ofDefaults() {
+        return new SimpleWorkflowClientConfig(Duration.ofSeconds(DEFAULT_POLLING_REQUEST_TIMEOUT_IN_SEC),
+                Duration.ofSeconds(DEFAULT_DATA_PLANE_REQUEST_TIMEOUT_IN_SEC),
+                Duration.ofSeconds(DEFAULT_CONTROL_PLANE_REQUEST_TIMEOUT_IN_SEC));
+    }
+
+    /**
+     * Create SimpleWorkflowClientConfig with polling/dataPlane/controlPlane timeouts
+     *
+     * @param pollingRequestTimeout timeout for polling APIs like PollForActivityTask, PollForDecisionTask
+     * @param dataPlaneRequestTimeout timeout for dataPlane APIs like StartWorkflowExecution, RespondActivityTaskCompleted
+     * @param controlPlaneRequestTimeout timeout for controlPlane APIs like ListDomains, ListActivityTypes
+     */
+    public SimpleWorkflowClientConfig(Duration pollingRequestTimeout, Duration dataPlaneRequestTimeout, Duration controlPlaneRequestTimeout) {
+        this.pollingRequestTimeout = pollingRequestTimeout;
+        this.dataPlaneRequestTimeout = dataPlaneRequestTimeout;
+        this.controlPlaneRequestTimeout = controlPlaneRequestTimeout;
+    }
+
+    public int getDataPlaneRequestTimeoutInMillis() {
+        return (int) dataPlaneRequestTimeout.toMillis();
+    }
+
+    public int getPollingRequestTimeoutInMillis() {
+        return (int) pollingRequestTimeout.toMillis();
+    }
+
+    public int getControlPlaneRequestTimeoutInMillis() {
+        return (int) controlPlaneRequestTimeout.toMillis();
+    }
+}

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/core/AsyncContextBase.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/core/AsyncContextBase.java
@@ -56,7 +56,10 @@ abstract class AsyncContextBase implements Runnable, AsyncParentContext {
         this.name = parent == null ? null : parent.getName();
         AsyncStackTrace parentStack = parent.getStackTrace();
         if (parentStack != null) {
-            stackTrace = new AsyncStackTrace(parentStack, Thread.currentThread().getStackTrace(), skipStackLines);
+            StackTraceElement[] stacktrace = System.getProperty("com.amazonaws.simpleworkflow.disableAsyncStackTrace", "false").equalsIgnoreCase("true") ?
+                    new StackTraceElement[0] :
+                    Thread.currentThread().getStackTrace();
+            stackTrace = new AsyncStackTrace(parentStack, stacktrace, skipStackLines);
             stackTrace.setStartFrom(parent.getParentTaskMethodName());
             stackTrace.setHideStartFromMethod(parent.getHideStartFromMethod());
         }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/generic/GenericWorkflowClient.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/generic/GenericWorkflowClient.java
@@ -39,7 +39,7 @@ public interface GenericWorkflowClient {
     public void continueAsNewOnCompletion(ContinueAsNewWorkflowExecutionParameters parameters);
 
     /**
-     * Deterministic unique Id generator
+     * Deterministic unique child workflow id generator
      */
     public String generateUniqueId();
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/replaydeserializer/TimeStampMixin.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/replaydeserializer/TimeStampMixin.java
@@ -12,16 +12,14 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-package com.amazonaws.services.simpleworkflow.flow.generic;
+package com.amazonaws.services.simpleworkflow.flow.replaydeserializer;
 
-import com.amazonaws.services.simpleworkflow.flow.core.Promise;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import java.util.Date;
 
-public interface StartChildWorkflowReply {
-
-    public String getWorkflowId();
-
-    public String getRunId();
-    
-    public Promise<String> getResult();
+public class TimeStampMixin {
+    @JsonDeserialize(using = TimestampDeserializer.class)
+    Date eventTimestamp;
 }
+

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/replaydeserializer/TimestampDeserializer.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/replaydeserializer/TimestampDeserializer.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.simpleworkflow.flow.replaydeserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.Date;
+
+public class TimestampDeserializer extends StdDeserializer<Date> {
+    public TimestampDeserializer() {
+        super(Date.class);
+    }
+
+    @Override
+    public Date deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        double milliseconds = Double.valueOf(jp.getText());
+        long timeInMillis = (long) (milliseconds * 1000);
+        return new Date(timeInMillis);
+    }
+}

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/retry/SynchronousRetrier.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/retry/SynchronousRetrier.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.simpleworkflow.flow.retry;
+
+import com.amazonaws.services.simpleworkflow.flow.worker.BackoffThrottler;
+import com.amazonaws.services.simpleworkflow.flow.worker.ExponentialRetryParameters;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * This class is for internal use only and may be changed or removed without prior notice.
+ *
+ */
+public class SynchronousRetrier extends Retrier {
+
+    private static final Log logger = LogFactory.getLog(SynchronousRetrier.class);
+
+    private final Class<?>[] exceptionsToNotRetry;
+
+    public SynchronousRetrier(ExponentialRetryParameters retryParameters, Class<?>... exceptionsToNotRetry) {
+        super(retryParameters, logger);
+        this.exceptionsToNotRetry = exceptionsToNotRetry;
+    }
+
+    public Class<?>[] getExceptionsToNotRetry() {
+        return exceptionsToNotRetry;
+    }
+
+    @Override
+    protected BackoffThrottler createBackoffThrottler() {
+        return new BackoffThrottler(getRetryParameters().getInitialInterval(),
+                getRetryParameters().getMaximumRetryInterval(), getRetryParameters().getBackoffCoefficient());
+    }
+
+    @Override
+    protected boolean shouldRetry(RuntimeException e) {
+        for (Class<?> exceptionToNotRetry : getExceptionsToNotRetry()) {
+            if (exceptionToNotRetry.isAssignableFrom(e.getClass())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/retry/ThrottlingRetrier.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/retry/ThrottlingRetrier.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.simpleworkflow.flow.retry;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.retry.RetryUtils;
+import com.amazonaws.services.simpleworkflow.flow.worker.BackoffThrottler;
+import com.amazonaws.services.simpleworkflow.flow.worker.BackoffThrottlerWithJitter;
+import com.amazonaws.services.simpleworkflow.flow.worker.ExponentialRetryParameters;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * A retrier only for throttling exception.
+ * This class is for internal use only and may be changed or removed without prior notice.
+ */
+public class ThrottlingRetrier extends Retrier {
+
+    private static final Log logger = LogFactory.getLog(ThrottlingRetrier.class);
+
+    public ThrottlingRetrier(ExponentialRetryParameters retryParameters) {
+        super(retryParameters, logger);
+    }
+
+    @Override
+    protected BackoffThrottler createBackoffThrottler() {
+        return new BackoffThrottlerWithJitter(getRetryParameters().getInitialInterval(),
+                getRetryParameters().getMaximumRetryInterval(), getRetryParameters().getBackoffCoefficient());
+    }
+
+    @Override
+    protected boolean shouldRetry(RuntimeException e) {
+        return e instanceof AmazonServiceException && RetryUtils.isThrottlingException((AmazonServiceException) e);
+    }
+}

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/spring/SpringActivityWorker.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/spring/SpringActivityWorker.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import com.amazonaws.services.simpleworkflow.flow.config.SimpleWorkflowClientConfig;
 import org.springframework.context.SmartLifecycle;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
@@ -48,12 +49,20 @@ public class SpringActivityWorker implements WorkerBase, SmartLifecycle {
         this(new GenericActivityWorker(service, domain, taskListToPoll));
     }
 
+    public SpringActivityWorker(AmazonSimpleWorkflow service, String domain, String taskListToPoll, SimpleWorkflowClientConfig config) {
+        this(new GenericActivityWorker(service, domain, taskListToPoll, config));
+    }
+
     public SpringActivityWorker(GenericActivityWorker genericWorker) {
         Objects.requireNonNull(genericWorker,"the activity worker is required");
 
         this.genericWorker = genericWorker;
         this.factory =  new POJOActivityImplementationFactory();
         this.genericWorker.setActivityImplementationFactory(factory);
+    }
+
+    public SimpleWorkflowClientConfig getClientConfig() {
+        return genericWorker.getClientConfig();
     }
 
     public AmazonSimpleWorkflow getService() {
@@ -178,28 +187,22 @@ public class SpringActivityWorker implements WorkerBase, SmartLifecycle {
         genericWorker.setExecuteThreadCount(threadCount);
     }
 
-    /**
-     * @deprecated This method has been deprecated since flow-3.7. Try using {@link #getExecuteThreadCount()} instead.
-     */
-    @Deprecated
-    public int getTaskExecutorThreadPoolSize() {
-        return genericWorker.getTaskExecutorThreadPoolSize();
-    }
-
-    /**
-     * @deprecated This method has been deprecated since flow-3.7. Try using {@link #setExecuteThreadCount(int)} instead.
-     */
-    @Deprecated
-    public void setTaskExecutorThreadPoolSize(int taskExecutorThreadPoolSize) {
-        genericWorker.setTaskExecutorThreadPoolSize(taskExecutorThreadPoolSize);
-    }
-
     public boolean isDisableServiceShutdownOnStop() {
         return genericWorker.isDisableServiceShutdownOnStop();
     }
 
     public void setDisableServiceShutdownOnStop(boolean disableServiceShutdownOnStop) {
         genericWorker.setDisableServiceShutdownOnStop(disableServiceShutdownOnStop);
+    }
+
+    @Override
+    public boolean isAllowCoreThreadTimeOut() {
+        return genericWorker.isAllowCoreThreadTimeOut();
+    }
+
+    @Override
+    public void setAllowCoreThreadTimeOut(boolean allowCoreThreadTimeOut) {
+        genericWorker.setAllowCoreThreadTimeOut(allowCoreThreadTimeOut);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/spring/SpringWorkflowWorker.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/spring/SpringWorkflowWorker.java
@@ -14,11 +14,13 @@
  */
 package com.amazonaws.services.simpleworkflow.flow.spring;
 
+import com.amazonaws.services.simpleworkflow.flow.ChildWorkflowIdHandler;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import com.amazonaws.services.simpleworkflow.flow.config.SimpleWorkflowClientConfig;
 import org.springframework.context.SmartLifecycle;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
@@ -53,11 +55,19 @@ public class SpringWorkflowWorker implements WorkerBase, SmartLifecycle {
         this(new GenericWorkflowWorker(service, domain, taskListToPoll));
     }
 
+    public SpringWorkflowWorker(AmazonSimpleWorkflow service, String domain, String taskListToPoll, SimpleWorkflowClientConfig config) {
+        this(new GenericWorkflowWorker(service, domain, taskListToPoll, config));
+    }
+
     public SpringWorkflowWorker(GenericWorkflowWorker genericWorker) {
         Objects.requireNonNull(genericWorker,"the workflow worker is required");
         this.genericWorker = genericWorker;
         this.factoryFactory  = new SpringWorkflowDefinitionFactoryFactory();
         this.genericWorker.setWorkflowDefinitionFactoryFactory(factoryFactory);
+    }
+
+    public SimpleWorkflowClientConfig getClientConfig() {
+        return genericWorker.getClientConfig();
     }
 
     public AmazonSimpleWorkflow getService() {
@@ -183,6 +193,16 @@ public class SpringWorkflowWorker implements WorkerBase, SmartLifecycle {
     }
 
     @Override
+    public boolean isAllowCoreThreadTimeOut() {
+        return genericWorker.isAllowCoreThreadTimeOut();
+    }
+
+    @Override
+    public void setAllowCoreThreadTimeOut(boolean allowCoreThreadTimeOut) {
+        genericWorker.setAllowCoreThreadTimeOut(allowCoreThreadTimeOut);
+    }
+
+    @Override
     public void setDisableTypeRegistrationOnStart(boolean disableTypeRegistrationOnStart) {
         genericWorker.setDisableTypeRegistrationOnStart(disableTypeRegistrationOnStart);
     }
@@ -220,6 +240,10 @@ public class SpringWorkflowWorker implements WorkerBase, SmartLifecycle {
     @Override
     public void setExecuteThreadCount(int threadCount) {
         genericWorker.setExecuteThreadCount(threadCount);
+    }
+
+    public void setChildWorkflowIdHandler(ChildWorkflowIdHandler childWorkflowIdHandler) {
+        genericWorker.setChildWorkflowIdHandler(childWorkflowIdHandler);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/test/TestGenericWorkflowClient.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/test/TestGenericWorkflowClient.java
@@ -56,9 +56,17 @@ public class TestGenericWorkflowClient implements GenericWorkflowClient {
 
         private final String runId;
 
-        private StartChildWorkflowReplyImpl(Settable<String> result, String runId) {
+        private final String workflowId;
+
+        private StartChildWorkflowReplyImpl(Settable<String> result, String workflowId, String runId) {
             this.result = result;
+            this.workflowId = workflowId;
             this.runId = runId;
+        }
+
+        @Override
+        public String getWorkflowId() {
+            return workflowId;
         }
 
         @Override
@@ -275,7 +283,7 @@ public class TestGenericWorkflowClient implements GenericWorkflowClient {
             throw failure;
         }
         finally {
-            reply.set(new StartChildWorkflowReplyImpl(result, runId));
+            reply.set(new StartChildWorkflowReplyImpl(result, workflowId, runId));
         }
     }
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/AsyncDecider.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/AsyncDecider.java
@@ -336,7 +336,7 @@ class AsyncDecider {
             decisionsHelper.handleRequestCancelExternalWorkflowExecutionFailed(event);
             break;
         case StartChildWorkflowExecutionInitiated:
-            decisionsHelper.handleStartChildWorkflowExecutionInitiated(event);
+            workflowClient.handleChildWorkflowExecutionInitiated(event);
             break;
         case CancelTimerFailed:
             decisionsHelper.handleCancelTimerFailed(event);

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/BackoffThrottler.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/BackoffThrottler.java
@@ -45,13 +45,13 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class BackoffThrottler {
 
-    private final long initialSleep;
+    protected final long initialSleep;
 
-    private final long maxSleep;
+    protected final long maxSleep;
 
-    private final double backoffCoefficient;
+    protected final double backoffCoefficient;
 
-    private final AtomicLong failureCount = new AtomicLong();
+    protected final AtomicLong failureCount = new AtomicLong();
 
     /**
      * Construct an instance of the throttler.
@@ -69,7 +69,7 @@ public class BackoffThrottler {
         this.backoffCoefficient = backoffCoefficient;
     }
 
-    private long calculateSleepTime() {
+    protected long calculateSleepTime() {
         double sleepMillis = (Math.pow(backoffCoefficient, failureCount.get() - 1)) * initialSleep;
         return Math.min((long) sleepMillis, maxSleep);
     }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/BackoffThrottlerWithJitter.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/BackoffThrottlerWithJitter.java
@@ -14,20 +14,23 @@
  */
 package com.amazonaws.services.simpleworkflow.flow.worker;
 
+import java.util.Random;
+
 /**
- * This interface is for internal use only and may be changed or removed without prior notice.
+ * This class is for internal use only and may be changed or removed without prior notice.
+ *
  */
-public interface TaskPoller<T>  {
+public class BackoffThrottlerWithJitter extends BackoffThrottler {
 
-    T poll() throws InterruptedException;
+    private final Random rand = new Random();
 
-    void execute(T task) throws Exception;
+    public BackoffThrottlerWithJitter(long initialSleep, long maxSleep, double backoffCoefficient) {
+        super(initialSleep, maxSleep, backoffCoefficient);
+    }
 
-    void suspend();
-
-    void resume();
-
-    boolean isSuspended();
-
-    SuspendableSemaphore getPollingSemaphore();
+    @Override
+    protected long calculateSleepTime() {
+        int delay = (int) (2 * initialSleep * Math.pow(backoffCoefficient, failureCount.get() - 1));
+        return Math.min(2 * maxSleep, rand.nextInt(delay));
+    }
 }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/BlockCallerPolicy.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/BlockCallerPolicy.java
@@ -18,12 +18,18 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 
 class BlockCallerPolicy implements RejectedExecutionHandler {
+    private static final Log log = LogFactory.getLog(BlockCallerPolicy.class);
 
     @Override
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
         try {
+            log.warn("Execution rejected. Blocking and adding to queue. Thread: " + Thread.currentThread().getName());
+
             // block until there's room
             executor.getQueue().put(r);
         }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/DecisionStateMachineBase.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/DecisionStateMachineBase.java
@@ -25,12 +25,11 @@ abstract class DecisionStateMachineBase implements DecisionStateMachine {
 
     protected List<String> stateHistory = new ArrayList<String>();
 
-    private final DecisionId id;
+    protected DecisionId id;
 
     public DecisionStateMachineBase(DecisionId id) {
         this.id = id;
         stateHistory.add(state.toString());
-
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
SWF-13061

*Description of changes:*

- Upgraded the Jackson dependencies to 2.13.x. Please check if your package is compatible with this major version of Jackson. We've received customer reports that Jackson upgrade (not necessarily Flow upgrade) can trigger deserialization error (for certain data types) in their workflows. To make it smooth, you'll need to bump up your workflow type accordingly and let old workflow executions drain out. Essentially you should use the same deployment strategy (e.g., have two fleets running two versions of workflows) as what you do for a workflow implementation change.
- Removed the deprecated setTaskExecutorThreadPoolSize() and getTaskExecutorThreadPoolSize() from GenericActivityWorker and ActivityWorker. To configure the polling thread count and task execution thread count for your activity worker, please use setExecuteThreadCount() and getExecuteThreadCount() instead.
- Removed the deprecated SpringGracefulShutdownActivityWorker and SpringGracefulShutdownWorkflowWorker classes from the AWSSimpleWorkflowJavaFlowSpring package. The SpringActivityWorker and SpringWorkflowWorker have the graceful shutdown logic in themselves.
- Support SimpleWorkflowClientConfig for tuning Flow Framework HTTP Request Timeouts.
- Improved the retry policy during worker startup to avoid startup failure due to RegisterActivityType and RegisterWorkflowType throttling.
- Truncated stack trace to comply with the length limit of the details field in the RespondActivityTaskFailed API. Since the details field has a maximum length of 32768, SWF will return 400s if the original exception has a large stack trace. This change truncates the stack trace in case of detail length exceeded, by preserving the first stack trace element and logging the original stack trace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
