### PR TITLE
Change maven publishing plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,14 +199,13 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>aws-swf</serverId>
-          <nexusUrl>https://aws.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>false</autoPublish>
         </configuration>
       </plugin>
     </plugins>
@@ -214,13 +213,46 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>aws-swf</id>
-      <url>https://aws.oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
     </snapshotRepository>
     <repository>
-      <id>aws-swf</id>
-      <url>https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>central</id>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
     </repository>
-
   </distributionManagement>
+
+  <profiles>
+    <profile>
+      <id>publishing</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>false</autoPublish>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
*Issue #, if available:*  Migration Required: Maven Central Publishing Process Change

*Description of changes:* A critical migration is required for all teams publishing to Maven Central due to an upcoming sunset of the legacy OSSRH (Open Source Software Repository Hosting) process that uses Nexus 2 Repository Manager. 


- Changes the Maven publishing configuration from nexus-staging-maven-plugin to central-publishing-maven-plugin (version 0.7.0)
- Updates the repository URLs from aws.oss.sonatype.org to ossrh-staging-api.central.sonatype.com
- Modifies the server IDs from 'aws-swf' to 'central' in the distribution management section

This change aligns with the required migration from Nexus 2 to Central Portal for Maven Central publishing.
